### PR TITLE
(fix) - Updated execute method of commands to always return int

### DIFF
--- a/src/Comcast/PhpLegalLicenses/Command/GenerateCommand.php
+++ b/src/Comcast/PhpLegalLicenses/Command/GenerateCommand.php
@@ -34,7 +34,7 @@ class GenerateCommand extends DependencyLicenseCommand
      *
      * @return void
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->hideVersion = $input->getOption('hide-version');
         $dependencies = $this->getDependencyList();
@@ -43,6 +43,8 @@ class GenerateCommand extends DependencyLicenseCommand
         $this->generateLicensesText($dependencies);
 
         $output->writeln('<info>Done!</info>');
+
+        return 0;
     }
 
     /**

--- a/src/Comcast/PhpLegalLicenses/Command/GenerateCommand.php
+++ b/src/Comcast/PhpLegalLicenses/Command/GenerateCommand.php
@@ -34,7 +34,7 @@ class GenerateCommand extends DependencyLicenseCommand
      *
      * @return void
      */
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->hideVersion = $input->getOption('hide-version');
         $dependencies = $this->getDependencyList();

--- a/src/Comcast/PhpLegalLicenses/Command/ShowCommand.php
+++ b/src/Comcast/PhpLegalLicenses/Command/ShowCommand.php
@@ -27,10 +27,12 @@ class ShowCommand extends DependencyLicenseCommand
      *
      * @return void
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $dependencies = $this->getDependencyList();
         $this->outputDependencyLicenses($dependencies, $output);
+
+        return 0;
     }
 
     /**

--- a/src/Comcast/PhpLegalLicenses/Command/ShowCommand.php
+++ b/src/Comcast/PhpLegalLicenses/Command/ShowCommand.php
@@ -27,7 +27,7 @@ class ShowCommand extends DependencyLicenseCommand
      *
      * @return void
      */
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
         $dependencies = $this->getDependencyList();
         $this->outputDependencyLicenses($dependencies, $output);


### PR DESCRIPTION
This commit corrects the bug caused by the upgrade to Symfony 5 as
the execute command expects an integer return value.