### PR TITLE
Symfony console and process vulnerability update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     "prefer-stable": true,
     "require": {
         "ext-json": "*",
-        "symfony/console": "~2.3|~3.0|~4.0|~5.0|~6.0|~7.0",
-        "symfony/process": "~2.3|~3.0|~4.0|~5.0|~6.0|~7.0"
+        "symfony/console": "~5.4.46|~6.0|~7.0",
+        "symfony/process": "~5.4.46|~6.0|~7.0"
     },
     "bin": [
         "bin/php-legal-licenses"


### PR DESCRIPTION
Updating symfony dependencies to require at least symfony/console and symfony/process v5.4.46

See CVE-2024-51736 and https://github.com/Comcast/php-legal-licenses/security/dependabot/1

Also changed minimum symfony/console and symfony/process version to v5.4.46, removing support for ~2.0, ~3.0, ~4.0.

Verified for PHP versions:
7.4 ✅
8.0 ✅
8.1 ✅
8.2 ✅
8.3 ✅
8.4 ✅