### PR TITLE
provide the escape param due to future deprecation

### DIFF
--- a/src/Comcast/PhpLegalLicenses/Command/GenerateCommand.php
+++ b/src/Comcast/PhpLegalLicenses/Command/GenerateCommand.php
@@ -78,7 +78,7 @@ class GenerateCommand extends DependencyLicenseCommand
         $fp = fopen('licenses.csv', 'w');
         $title = ['name', 'version', 'source', 'license description'];
 
-        fputcsv($fp, $title);
+        fputcsv($fp, $title, ",", '"', "\\");
         foreach ($dependencies as $dependency) {
             $dependencyLists = [
                 $dependency['name'],
@@ -86,7 +86,7 @@ class GenerateCommand extends DependencyLicenseCommand
                 $dependency['source']['url'],
                 $this->getTextForDependency($dependency),
             ];
-            fputcsv($fp, $dependencyLists);
+            fputcsv($fp, $dependencyLists, ",", '"', "\\");
         }
         fclose($fp);
     }


### PR DESCRIPTION
https://php.watch/versions/8.4/csv-functions-escape-parameter

this prevents the warning that fills the cli output:
`Deprecated: fputcsv(): the $escape parameter must be provided as its default value will change`