### PR TITLE
Update GenerateCommand for Symfony 8 compatibility

### DIFF
--- a/bin/php-legal-licenses
+++ b/bin/php-legal-licenses
@@ -10,6 +10,8 @@ if (file_exists(__DIR__.'/../vendor/autoload.php')) {
 }
 
 $app = new Symfony\Component\Console\Application('PHP Legal Licenses', '1.2.0');
-$app->add(new Comcast\PhpLegalLicenses\Console\GenerateCommand);
-$app->add(new Comcast\PhpLegalLicenses\Console\ShowCommand);
+$app->addCommands([
+    new Comcast\PhpLegalLicenses\Console\GenerateCommand,
+    new Comcast\PhpLegalLicenses\Console\ShowCommand
+]);
 $app->run();

--- a/src/Comcast/PhpLegalLicenses/Command/GenerateCommand.php
+++ b/src/Comcast/PhpLegalLicenses/Command/GenerateCommand.php
@@ -19,7 +19,7 @@ class GenerateCommand extends DependencyLicenseCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('generate')

--- a/src/Comcast/PhpLegalLicenses/Command/ShowCommand.php
+++ b/src/Comcast/PhpLegalLicenses/Command/ShowCommand.php
@@ -12,7 +12,7 @@ class ShowCommand extends DependencyLicenseCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
         ->setName('show')


### PR DESCRIPTION
This PR updates the `GenerateCommand` class to be compatible with Symfony 8 and replaces the deprecated `add` function with `addCommands`.

### Changes Made:
- Updated the `configure()` method in `GenerateCommand` to include the `void` return type declaration.
- Replaced the deprecated `add` function with `addCommands` for adding commands.

### Reason for Changes:
- Symfony 8 requires the `configure()` method to return `void`.
- The `add` function is deprecated in favor of `addCommands`.

### Related Issue:
- Closes #29