### PR TITLE
add method was deprecated in symfony 7.4 in favor of addCommand. 

### DIFF
--- a/bin/php-legal-licenses
+++ b/bin/php-legal-licenses
@@ -10,6 +10,13 @@ if (file_exists(__DIR__.'/../vendor/autoload.php')) {
 }
 
 $app = new Symfony\Component\Console\Application('PHP Legal Licenses', '1.2.0');
-$app->add(new Comcast\PhpLegalLicenses\Console\GenerateCommand);
-$app->add(new Comcast\PhpLegalLicenses\Console\ShowCommand);
+
+if (method_exists($app, 'addCommand')) {
+    $app->addCommand(new Comcast\PhpLegalLicenses\Console\GenerateCommand());
+    $app->addCommand(new Comcast\PhpLegalLicenses\Console\ShowCommand());
+} else {
+    $app->add(new Comcast\PhpLegalLicenses\Console\GenerateCommand());
+    $app->add(new Comcast\PhpLegalLicenses\Console\ShowCommand());
+}
+
 $app->run();

--- a/src/Comcast/PhpLegalLicenses/Command/GenerateCommand.php
+++ b/src/Comcast/PhpLegalLicenses/Command/GenerateCommand.php
@@ -19,7 +19,7 @@ class GenerateCommand extends DependencyLicenseCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('generate')

--- a/src/Comcast/PhpLegalLicenses/Command/ShowCommand.php
+++ b/src/Comcast/PhpLegalLicenses/Command/ShowCommand.php
@@ -12,7 +12,7 @@ class ShowCommand extends DependencyLicenseCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
         ->setName('show')


### PR DESCRIPTION
Sincee we still allow versions <7.4, added a check if addCommand exists, or default back to add.

closes #30